### PR TITLE
remove buy links from /phone

### DIFF
--- a/templates/phone/index.html
+++ b/templates/phone/index.html
@@ -116,21 +116,18 @@
             <div class="twelve-col align-center">
                 <img src="{{ STATIC_URL }}img/phone/bq-e5-single.png" height="180" alt="BQ Aquaris E5 HD" />
             </div>
-            <p><a href="https://store.bq.com/gl/ubuntu-edition-e5/" class="external">如何购买</a></p>
         </div>
         <div class="four-col">
             <h3>BQ Aquaris E4.5</h3>
             <div class="twelve-col align-center">
                 <img src="{{ STATIC_URL }}img/phone/bq-e4.5-single.png" height="180" alt="BQ Aquaris E4.5" />
             </div>
-            <p><a href="https://store.bq.com/gl/ubuntu-edition-e-4-5-fr/" class="external">如何购买</a></p>
         </div>
         <div class="four-col last-col">
             <h3>魅族MX4 Ubuntu版本</h3>
             <div class="twelve-col align-center">
                 <img src="{{ STATIC_URL }}img/phone/meizu-mx4-single.png" height="180" alt="魅族MX4 Ubuntu版本" />
             </div>
-            <p>售罄</p>
         </div>
     </div>
     <div class="eight-col">


### PR DESCRIPTION
## Done

* removed buy links and button on the /phone page like we have on ubuntu.com

## QA


1. go to /phone
2. see no buy links or buttons like in the [copy doc](https://docs.google.com/document/d/1wrS0ojZ4B_2UdbxDyIzr-iZPA_ti-JCxtO9QXfoKdUw/edit)


## Issue / Card

Fixes #114

## Screenshots
![image](https://cloud.githubusercontent.com/assets/441217/20427505/37ed06f4-ad7c-11e6-85f2-0ea18b8a1e0a.png)

