### PR TITLE
remove link to out-of-date video and correct the name of Youku

### DIFF
--- a/templates/news/index.html
+++ b/templates/news/index.html
@@ -72,8 +72,7 @@
 <div class="row no-border">
     <h2>Videos</h2>
     <ul class="">
-        <li><a class="external" href="http://i.youku.com/u/UNTU5ODQxNjg0">Celebrate Ubuntu YouKy channel</a></li>
-        <li><a class="external" href="http://v.youku.com/v_show/id_XNTA2NDczNDE2">视频: 友帮拓手机 - 产业专题</a></li>
+        <li><a class="external" href="http://i.youku.com/u/UNTU5ODQxNjg0">Celebrate Ubuntu Youku channel</a></li>
     </ul>
 </div>
 


### PR DESCRIPTION
## Done

 - Removed the last link on the `/news` page
 - Corrected the spelling of Youku

## QA

Check `/news` in browser and see that the changes above have been made.

Fixes #117 